### PR TITLE
Agregar servicios de pagos y respuesta de preferencia de pago

### DIFF
--- a/src/app/models/payment.responses.ts
+++ b/src/app/models/payment.responses.ts
@@ -1,0 +1,26 @@
+export interface preferenciaPagoResponse {
+    success: boolean;
+    data: Data;
+    message: string;
+}
+
+interface Data {
+    pago_id: string;
+    preference_id: string;
+    init_point: string;
+    sandbox_init_point: string;
+}
+
+export interface Pago {
+    success: boolean;
+    data: Datum[];
+    total_pendiente: number;
+}
+
+interface Datum {
+    id: string;
+    monto: number;
+    estado: string;
+    fecha_creacion: Date;
+    descripcion: string;
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -110,6 +110,10 @@ export class AuthService {
 
   isLoggedIn(): boolean {
     const token = this.getAccessToken();
+    if (token && this.isTokenExpired(token)) {
+      this.logout();
+      return false;
+    }
     return token != null && !this.isTokenExpired(token);
   }
 

--- a/src/app/services/pagos.service.ts
+++ b/src/app/services/pagos.service.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+import { lastValueFrom } from 'rxjs';
+import { Pago, preferenciaPagoResponse } from '../models/payment.responses';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PagosService {
+  /**
+   * Servicio para gestionar los pagos con mercadopago.
+   * Este servicio se encarga de realizar las peticiones a la API de pagos.
+   */
+
+  // Inyecciones
+  private http = inject(HttpClient);
+
+  private readonly apiUrl = `${environment.apiUrl}/pagos/`;
+
+  async crearPreferenciaPago(reserva_id: string) {
+    /**
+     * Crea una preferencia de pago para una reserva.
+     * @param reserva_id ID de la reserva para la que se crea la preferencia de pago.
+     * @returns Una promesa que resuelve con la URL de pago.
+     */
+    const url = `${this.apiUrl}crear-preferencia/${reserva_id}`;
+    const response = await lastValueFrom(this.http.post<preferenciaPagoResponse>(url, {}));
+    return response;
+  }
+
+  obtenerMisComisiones() {
+    /**
+     * Obtiene las comisiones pendientes de pago del usuario.
+     * @returns Una promesa que resuelve con un array de comisiones.
+     */
+    const url = `${this.apiUrl}comisiones/mis-pagos`;
+    return lastValueFrom(this.http.get<Pago[]>(url));
+  }
+
+  obtenerEstadoPago(pago_id: string) {
+    const url = `${this.apiUrl}estado/${pago_id}`;
+    return lastValueFrom(this.http.get<Pago>(url));
+  }
+}


### PR DESCRIPTION
Implementar un servicio para gestionar pagos, incluyendo la creación de preferencias de pago y la obtención de comisiones pendientes. Integrar el servicio en el flujo de reservas para redirigir a los usuarios a la URL de pago.